### PR TITLE
Add portString arg to clearTimers()

### DIFF
--- a/MATLAB/LickSense.m
+++ b/MATLAB/LickSense.m
@@ -67,7 +67,7 @@ classdef LickSense < handle
             % Args: portName (the USB serial port name, e.g. 'COM3')
 
             % Clear orphaned timers from previous instances
-            obj.clearTimers;
+            obj.clearTimers(portName);
 
             % Setup USB serial port
             obj.Port = ArCOM_LickSense(portName, 480000000);
@@ -351,7 +351,7 @@ classdef LickSense < handle
             obj.Port.flush;
         end
 
-        function clearTimers(obj)
+        function clearTimers(obj, portString)
             % Destroy any orphaned timers from previous instances
             T = timerfindall;
             for i = 1:length(T)


### PR DESCRIPTION
If `timerfindall` returns any timers then object initialisation fails because `portString` reference doesn't exist. `obj.Port.PortName` doesn't exist yet, so I've added the name of the port into the method.